### PR TITLE
hotfix for basicBeeSpawnTimeInterval

### DIFF
--- a/Bumble Boogie/State/GameState/GameState.swift
+++ b/Bumble Boogie/State/GameState/GameState.swift
@@ -24,8 +24,7 @@ class GameState: ObservableObject {
             TotalHoney = SavedTotalHoney
         }
     }
-    
-    @Published var basicBeeSpawnInterval: TimeInterval = 1.0
+
     
     // Runtime Vars
     @Published var UpgradeCost: Int = 20

--- a/Bumble Boogie/State/TimeManagement/GameTimeManager.swift
+++ b/Bumble Boogie/State/TimeManagement/GameTimeManager.swift
@@ -13,16 +13,7 @@ import Foundation
 class GameTimeManager: ObservableObject {
     
     var gameState = GameState()
-    
-//    let basicBeeSpawnInterval: String
-//    if let unwrappedValue = gameState.variableName {
-//        variableValue = unwrappedValue
-//    } else {
-//        variableValue = "Default Value"
-//    }
-    
-    // TODO
-    /// Implement a timer that runs and triggers events while the game is closed.
+
     
     // Accumulated (global) time in seconds since the game started.
     private(set) var masterTimer: DispatchSourceTimer?
@@ -38,7 +29,22 @@ class GameTimeManager: ObservableObject {
 
     
     var conductorAccumulator: TimeInterval = 0.0
-    var basicBeeSpawnAccumulator: TimeInterval = 0.0
+    
+    @Published var basicBeeSpawnInterval: TimeInterval = 1.0{
+        didSet {
+            UserDefaultsMemoryManager.shared.set(basicBeeSpawnInterval, forKey: .basicBeeSpawnInterval)
+        }
+    }
+    
+    init() {
+        if let savedBasicBeeSpawnInterval: TimeInterval = UserDefaultsMemoryManager.shared.get(forKey: .basicBeeSpawnInterval) {
+            basicBeeSpawnInterval = savedBasicBeeSpawnInterval
+        }
+    }
+    
+    
+    
+    @Published var basicBeeSpawnAccumulator: TimeInterval = 0.0
     
     // Indicated if the game is paused
     private(set) var isPaused: Bool = false
@@ -78,9 +84,10 @@ class GameTimeManager: ObservableObject {
         }
         
         basicBeeSpawnAccumulator += deltaTime
-        if basicBeeSpawnAccumulator >= gameState.basicBeeSpawnInterval { // uses force unwrapping as game state is always present
+        if basicBeeSpawnAccumulator >= basicBeeSpawnInterval {
             basicBeeSpawnAccumulator = 0
             onBasicBeeSpawnIntervalTick?()
+        
         }
     }
     

--- a/Bumble Boogie/State/TimeManagement/TimeManagementExtensions/SpawnRateExtension.swift
+++ b/Bumble Boogie/State/TimeManagement/TimeManagementExtensions/SpawnRateExtension.swift
@@ -13,21 +13,21 @@ extension GameTimeManager {
     // Basic bees spawn more frequently by DECREASING the interval
     func increaseBasicBeeSpawnRate() {
         // decrease the interval but clamped to a safe minimum
-        gameState.basicBeeSpawnInterval = max(0.2, gameState.basicBeeSpawnInterval - 0.2)
+        basicBeeSpawnInterval = max(0.2, basicBeeSpawnInterval - 0.2)
         
         // Optionally reset the accumulator so the change takes immediate effect.
         /// (If you want the partial accumulated time to remain, omit this line.)
         basicBeeSpawnAccumulator = 0
-        print("spawnRate is \(gameState.basicBeeSpawnInterval)")
+        print("spawnRate is \(basicBeeSpawnInterval)")
     }
     
     // Basic bees spawn less fequently by INCREASING the interval
     func decreaseBasicBeeSpawnRate() {
-        gameState.basicBeeSpawnInterval = max(10.0, gameState.basicBeeSpawnInterval + 0.5)
+     basicBeeSpawnInterval = max(10.0, basicBeeSpawnInterval + 0.5)
         
         // Optionally reset the accumulator so the change takes immediate effect.
         /// (If you want the partial accumulated time to remain, omit this line.)
         basicBeeSpawnAccumulator = 0
-        print("spawnRate is \(gameState.basicBeeSpawnInterval)")
+        print("spawnRate is \(basicBeeSpawnInterval)")
     }
 }

--- a/Bumble Boogie/State/UserDefaultsMemoryManager.swift
+++ b/Bumble Boogie/State/UserDefaultsMemoryManager.swift
@@ -14,6 +14,7 @@ class UserDefaultsMemoryManager {
     
     enum Keys: String {
         case TotalHoney
+        case basicBeeSpawnInterval
         //Other values…
     }
     

--- a/Bumble Boogie/Views/ContentView.swift
+++ b/Bumble Boogie/Views/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
             VStack {
                 Text("Currency: \(gameState.TotalHoney)")
                     .font(.custom("Bloxic", size: 28))
-                Text("spawnRate: \(gameState.basicBeeSpawnInterval)")
+                Text("spawnRate: \(gameTimeManager.basicBeeSpawnInterval)")
                     .frame(width:375)
                     .padding(24)
                     .font(.custom("Bloxic", size: 16))


### PR DESCRIPTION
hot fix for basicBeeSpawnTimeInterval not being reflected accurately in swiftUI component

- moved key variable out of GameStateManager and into Timer manager
- cached value into userDefaultsMemory for data persistence between sessions
- Updated userDefaultsMemoryManager Keys 