### PR TITLE
added touch processing flag to beeNode

### DIFF
--- a/Bumble Boogie/Components/GameObjects/BasicBee.swift
+++ b/Bumble Boogie/Components/GameObjects/BasicBee.swift
@@ -29,6 +29,7 @@ class BasicBeeSprite : SKSpriteNode{
     private let verticalSpeed: CGFloat
     private(set) var trailEmitter: SKEmitterNode?
     private var debugMode: Bool = false
+    private var isProcessingTouch: Bool = false
     
     //MARK: - Animation properties
     private var spriteFrames: [SKTexture] = []
@@ -200,7 +201,10 @@ class BasicBeeSprite : SKSpriteNode{
             self.removeAllActions()
             let scaleUpAction = SKAction.scale(to: self.xScale * 1.2, duration: 0.1)
             let scaleDownAction = SKAction.scale(to: 0.0, duration: 0.2)
-            let removeAction = SKAction.removeFromParent()
+            let removeAction = SKAction.run { [weak self] in
+            self?.cleanUp()
+            }
+        
             let removalSequence = SKAction.sequence([scaleUpAction, scaleDownAction, removeAction])
         
             self.run(removalSequence)
@@ -210,8 +214,12 @@ class BasicBeeSprite : SKSpriteNode{
     
     //MARK: - For interactivity within the node
     override func touchesBegan (_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let touch = touches.first,
+        guard !isProcessingTouch,
+              let touch = touches.first,
               let scene = self.scene else { return }
+        
+        // Set flag
+        isProcessingTouch = true
         
         //convert touch position into passable coordinates
         let touchPostionInNode = touch.location(in: self)
@@ -252,6 +260,7 @@ class BasicBeeSprite : SKSpriteNode{
     }
     
     func cleanUp() {
+        isProcessingTouch = false
         removeAllActions()
         trailEmitter?.removeFromParent()
         removeFromParent()


### PR DESCRIPTION
This pull request includes changes to the `BasicBeeSprite` class in the `Bumble Boogie/Components/GameObjects/BasicBee.swift` file to improve touch handling and cleanup processes. The most important changes include adding a flag to prevent multiple touch processing, modifying the removal action to ensure cleanup, and resetting the touch processing flag during cleanup.

Improvements to touch handling:

* [`Bumble Boogie/Components/GameObjects/BasicBee.swift`](diffhunk://#diff-b84c9a6139f98935eac8af5efb6f5ed0032261c77db715e48447baf0a6b73507R32): Added the `isProcessingTouch` flag to prevent multiple touch events from being processed simultaneously. [[1]](diffhunk://#diff-b84c9a6139f98935eac8af5efb6f5ed0032261c77db715e48447baf0a6b73507R32) [[2]](diffhunk://#diff-b84c9a6139f98935eac8af5efb6f5ed0032261c77db715e48447baf0a6b73507L213-R223)

Enhancements to cleanup process:

* [`Bumble Boogie/Components/GameObjects/BasicBee.swift`](diffhunk://#diff-b84c9a6139f98935eac8af5efb6f5ed0032261c77db715e48447baf0a6b73507L203-R207): Modified the removal action to call the `cleanUp` method using a weak reference to self, ensuring proper cleanup before removal.
* [`Bumble Boogie/Components/GameObjects/BasicBee.swift`](diffhunk://#diff-b84c9a6139f98935eac8af5efb6f5ed0032261c77db715e48447baf0a6b73507R263): Reset the `isProcessingTouch` flag in the `cleanUp` method to allow for future touch events.