### PR TITLE
fixed concurrency issue

### DIFF
--- a/Bumble Boogie/Components/GameObjects/FlowerNode.swift
+++ b/Bumble Boogie/Components/GameObjects/FlowerNode.swift
@@ -47,7 +47,7 @@ class FlowerNode: SKSpriteNode {
     
     
     //MARK: - Init
-    init(powerUpType: PowerUpType, lifeSpan: TimeInterval = 0.3, size: CGSize = CGSize(width: 80, height: 80)){
+    init(powerUpType: PowerUpType, lifeSpan: TimeInterval, size: CGSize = CGSize(width: 80, height: 80)){
         print("Before super.init - lifeSpan: \(lifeSpan)")
         self.powerUpType = powerUpType
         self.duration = powerUpType.duration

--- a/Bumble Boogie/Scenes/MainGameScene.swift
+++ b/Bumble Boogie/Scenes/MainGameScene.swift
@@ -88,7 +88,7 @@ class MainGameScene: SKScene, SKPhysicsContactDelegate {
             scene: self,
             gridManager: gridManager,
             gameState: sharedGameState,
-            maxConcurrentFlowers: 3
+            maxConcurrentFlowers: 5
         )
     }
     

--- a/Bumble Boogie/State/Managers/FlowerManager.swift
+++ b/Bumble Boogie/State/Managers/FlowerManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import SpriteKit
 
 @MainActor
+
 class FlowerManager {
     
     // MARK: - Properties
@@ -21,40 +22,92 @@ class FlowerManager {
     private let maxConcurrentFlowers: Int
     private var pauseObserverId: UUID?
     
+    private var lastSpawnTime: TimeInterval = 0
+    private let minTimeBetweenSpawns: TimeInterval = 0.5
+    private var flowerSpawnQueue: Int = 0
+    
+    // For task cancellation
+    private var spawnProcessingTask: Task<Void, Never>? = nil
+    
+    //debug vars
+    private var tickCount = 0
+    
     // MARK: - Initialization
-      init(scene: SKScene,
-           gridManager: GridManager,
-           gameState: GameState,
-           maxConcurrentFlowers: Int = 5) {
-          self.scene = scene
-          self.gridManager = gridManager
-          self.gameState = gameState
-          self.maxConcurrentFlowers = maxConcurrentFlowers
-          
-          setupCallbacks()
-      }
+    init(scene: SKScene,
+         gridManager: GridManager,
+         gameState: GameState,
+         maxConcurrentFlowers: Int) {
+        self.scene = scene
+        self.gridManager = gridManager
+        self.gameState = gameState
+        self.maxConcurrentFlowers = maxConcurrentFlowers
+        
+        setupCallbacks()
+    }
     
     private func setupCallbacks() {
         // Set the callback in GameState
         gameState.onFlowerSpawnIntervalTick = { [weak self] in
-            print("Flower spawn interval ticked")
-            self?.trySpawnFlower()
+            guard let self = self else { return }
+            self.tickCount += 1
+            print("🌸 Flower spawn interval ticked (#\(self.tickCount))")
+            self.queueFlowerSpawn()
         }
         
         pauseObserverId = UUID()
         GamePauseManager.shared.addPauseStateObserver { [weak self] isPaused in
             self?.handlePauseState(isPaused)
         }
+        
+        setupSpawnProcessing()
+    }
+    
+    
+    private func setupSpawnProcessing() {
+        /// creates a repeating task on the main actor to process the queue
+        spawnProcessingTask = Task {
+            while !Task.isCancelled {
+                processFlowerSpawnQueue()
+                try? await Task.sleep(nanoseconds: 500_000_000 ) // 0.5 seconds
+            }
+        }
+    }
+    
+    // MARK: - Flower Spawning System
+    
+    // Queue a flower spawn when a tick happens
+    private func queueFlowerSpawn() {
+        let spaceAvailable = maxConcurrentFlowers - activeFlowers.count
+        if spaceAvailable > 0 {
+            let flowersToQueue = spaceAvailable
+            flowerSpawnQueue += flowersToQueue
+            print ("max concurrent flowers is \(maxConcurrentFlowers)")
+            print("🌸 Queued \(flowersToQueue) flowers, queue size: \(flowerSpawnQueue), active flowers: \(activeFlowers.count)")
+        } else {
+            print("🌸 Max flowers reached, not queing any more")
+        }
+    }
+    
+    private func processFlowerSpawnQueue() {
+        guard !gameState.isPaused && flowerSpawnQueue > 0  else { return }
+        
+        let currentTime = CACurrentMediaTime()
+        if currentTime - lastSpawnTime >= minTimeBetweenSpawns {
+            spawnSingleFlower()
+            flowerSpawnQueue -= 1
+            print("🌸 Processed queue: remaining in queue: \(flowerSpawnQueue)")
+        }
     }
     
     
     //MARK: - Flower management
-    func trySpawnFlower() {
+    
+    private func spawnSingleFlower() {
         
-        cleanupInvalidFlowers()
+        cleanupInvalidFlowers( )
         
         guard activeFlowers.count < maxConcurrentFlowers else {
-            print("Max flowers reached \(maxConcurrentFlowers)")
+            print ("Max flowers reached \(maxConcurrentFlowers)")
             return
         }
         
@@ -62,10 +115,17 @@ class FlowerManager {
             let flower = createFlower(at: spawnPoint)
             activeFlowers.insert(flower)
             scene.addChild(flower)
-            print("Flower spawned at \(spawnPoint.position)")
+            lastSpawnTime = CACurrentMediaTime()
+            print( "Flower spawned at \(spawnPoint.position), total active: \(activeFlowers.count)" )
         } else {
-            print("No available spawn points")
+            print( "No available spawn points" )
         }
+    }
+    
+    
+    func trySpawnFlowers() {
+        
+        queueFlowerSpawn()
     }
     
     
@@ -73,7 +133,7 @@ class FlowerManager {
         let powerUpTypes: [PowerUpType] = [.speedBoost, .honeyMultiplier]
         let randomType = powerUpTypes.randomElement()!
         
-        let flower = FlowerNode(powerUpType: randomType, lifeSpan: 3.0)
+        let flower = FlowerNode(powerUpType: randomType, lifeSpan: gameState.progress.flowerLifespan)
         flower.position = spawnPoint.position
         flower.spawnPoint = spawnPoint
         
@@ -99,41 +159,45 @@ class FlowerManager {
         }
     }
     
-
+    
     // MARK: - Cleanup
-        func cleanup() {
-            activeFlowers.forEach { flower in
-                flower.removeFromParent()
-                if let spawnPoint = flower.spawnPoint {
-                    gridManager.releasePoint(spawnPoint)
-                }
-            }
-            activeFlowers.removeAll()
-            
-            if let observerId = pauseObserverId {
-                GamePauseManager.shared.removePauseStateObservers(observerId)
-                pauseObserverId = nil
-            }
-        }
-        
-        private func cleanupInvalidFlowers() {
-            activeFlowers = activeFlowers.filter { flower in
-                if flower.parent == nil {
-                    print("Removing invalid flower reference")
+            func cleanup() {
+                // Cancel any ongoing spawn tasks
+                spawnProcessingTask?.cancel()
+                spawnProcessingTask = nil
+                
+                activeFlowers.forEach { flower in
+                    flower.removeFromParent()
                     if let spawnPoint = flower.spawnPoint {
                         gridManager.releasePoint(spawnPoint)
                     }
-                    return false
                 }
-                return true
+                activeFlowers.removeAll()
+                
+                if let ObserverId = pauseObserverId {
+                    GamePauseManager.shared.removePauseStateObservers(ObserverId)
+                    pauseObserverId = nil
+                }
             }
-        }
-        
-        // MARK: - Debug
-        var debugInfo: String {
+            
+            private func cleanupInvalidFlowers() {
+                activeFlowers = activeFlowers.filter { flower in
+                    if flower.parent == nil {
+                        print("Removing invalid flower reference")
+                        if let spawnPoint = flower.spawnPoint {
+                            gridManager.releasePoint(spawnPoint)
+                        }
+                        return false
+                    }
+                    return true
+                }
+            }
+    
+    // MARK: - Debug
+    var debugInfo: String {
             """
             Active Flowers: \(activeFlowers.count)
             Max Flowers: \(maxConcurrentFlowers)
             Currently Paused: \(gameState.isPaused)
             """
-        }}
+    }}


### PR DESCRIPTION
This pull request includes several changes to the `Bumble Boogie` game to enhance the flower spawning system and adjust some game parameters. The most important changes include modifications to the `FlowerManager` class to introduce a queue-based flower spawning system, updates to the `MainGameScene` to increase the maximum number of concurrent flowers, and minor adjustments to the `FlowerNode` initialization.

Enhancements to flower spawning system:

* [`Bumble Boogie/State/Managers/FlowerManager.swift`](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088R25-R39): Introduced a queue-based flower spawning system with new properties and methods (`lastSpawnTime`, `minTimeBetweenSpawns`, `flowerSpawnQueue`, `setupSpawnProcessing`, `queueFlowerSpawn`, `processFlowerSpawnQueue`, `spawnSingleFlower`). This includes a task to process the queue at regular intervals. [[1]](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088R25-R39) [[2]](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088L40-R105) [[3]](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088L65-R136) [[4]](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088R165-R168) [[5]](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088L113-R178)

Game parameter adjustments:

* [`Bumble Boogie/Scenes/MainGameScene.swift`](diffhunk://#diff-309541d0a34119f8896b2c446d312ed55c02953f1c8e38a28d5b0753455323fcL91-R91): Increased the `maxConcurrentFlowers` from 3 to 5.

Initialization adjustments:

* [`Bumble Boogie/Components/GameObjects/FlowerNode.swift`](diffhunk://#diff-72202f11ad3837e4972f8c729e679ea8b328a16afb1aca756591980edccdb565L50-R50): Removed the default value for the `lifeSpan` parameter in the `FlowerNode` initializer.

Minor improvements:

* [`Bumble Boogie/State/Managers/FlowerManager.swift`](diffhunk://#diff-a0a4d553be5741c76cc4892f9570c989008e6fdb8b72a58d62a8dac39b4be088R12): Added a blank line after the `@MainActor` attribute for better readability.